### PR TITLE
Vectorize slerp and remove custom code for create_group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jax-scipy-spatial"
-version = "0.2.3"
+version = "0.2.4"
 description = "Scipy spatial API for JAX"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
This makes two changes:

1. Move business logic contained in the `Slerp` class to `_slerp` function
2. Remove the business logic for `create_group`, let scipy handle this

This has the following benefits:

1. Code is simpler
2. Slerp can handle `time` input with any number of dimensions
3. Allow option to use a plain slerp function instead of a class if desired