### PR TITLE
JAX 9.0

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -17,10 +17,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.12
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.13
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -11,17 +11,20 @@ jobs:
     runs-on: [ ubuntu-latest ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-
-      - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.12
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.13
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.14
 
       - name: Install dependencies
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 name = "jax-scipy-spatial"
 version = "0.2.5"
 description = "Scipy spatial API for JAX"
+license = "Apache-2.0"
 readme = "README.md"
 authors = [
     { name = "Chris Flesher", email = "chris.flesher@gmail.com" }
@@ -13,7 +14,6 @@ classifiers = [
     "Intended Audience :: Financial and Insurance Industry",
     "Intended Audience :: Information Technology",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
@@ -33,6 +33,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "absl-py",
+    "build",
     "pytest",
     "scipy",
     "tox",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
 dependencies = [
     "jax",
     "jaxlib",
-    "scipy",
 ]
 
 [project.urls]
@@ -35,6 +34,7 @@ dependencies = [
 dev = [
     "absl-py",
     "pytest",
+    "scipy",
     "tox",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "absl-py",
+    "pytest",
     "tox",
 ]
 

--- a/src/jax_scipy_spatial/distance.py
+++ b/src/jax_scipy_spatial/distance.py
@@ -19,13 +19,8 @@ import scipy.spatial.distance
 
 import jax
 import jax.numpy as jnp
-try:
-  from jax._src.numpy.util import implements
-except ImportError:
-  from jax._src.numpy.util import _wraps as implements  # for jax < 0.4.25
 
 
-@implements(scipy.spatial.distance.braycurtis)
 def braycurtis(u: jax.Array, v: jax.Array, w: typing.Optional[jax.Array] = None) -> jax.Array:
   """Compute the Bray-Curtis distance between two 1-D arrays."""
   l1_diff = jnp.abs(u - v)
@@ -36,7 +31,6 @@ def braycurtis(u: jax.Array, v: jax.Array, w: typing.Optional[jax.Array] = None)
   return jnp.sum(l1_diff) / jnp.sum(l1_sum)
 
 
-@implements(scipy.spatial.distance.canberra)
 def canberra(u: jax.Array, v: jax.Array, w: typing.Optional[jax.Array] = None) -> jax.Array:
   """Compute the Canberra distance between two 1-D arrays."""
   l1_diff = jnp.abs(u - v)
@@ -48,7 +42,6 @@ def canberra(u: jax.Array, v: jax.Array, w: typing.Optional[jax.Array] = None) -
   return jnp.nansum(d)
 
 
-@implements(scipy.spatial.distance.chebyshev)
 def chebyshev(u: jax.Array, v: jax.Array, w: typing.Optional[jax.Array] = None) -> jax.Array:
   """Compute the Chebyshev distance."""
   l1_diff = jnp.abs(u - v)
@@ -57,7 +50,6 @@ def chebyshev(u: jax.Array, v: jax.Array, w: typing.Optional[jax.Array] = None) 
   return jnp.max(l1_diff)
 
 
-@implements(scipy.spatial.distance.cityblock)
 def cityblock(u: jax.Array, v: jax.Array, w: typing.Optional[jax.Array] = None) -> jax.Array:
   """Compute the City Block (Manhattan) distance."""
   l1_diff = jnp.abs(u - v)
@@ -66,7 +58,6 @@ def cityblock(u: jax.Array, v: jax.Array, w: typing.Optional[jax.Array] = None) 
   return jnp.sum(l1_diff)
 
 
-@implements(scipy.spatial.distance.correlation)
 def correlation(u: jax.Array, v: jax.Array, w: typing.Optional[jax.Array] = None, centered: bool = True) -> jax.Array:
   """Compute the correlation distance between two 1-D arrays."""
   if centered:
@@ -81,28 +72,24 @@ def correlation(u: jax.Array, v: jax.Array, w: typing.Optional[jax.Array] = None
   return jnp.abs(dist)
 
 
-@implements(scipy.spatial.distance.cosine)
 def cosine(u: jax.Array, v: jax.Array, w: typing.Optional[jax.Array] = None) -> jax.Array:
   """Compute the Cosine distance between 1-D arrays."""
   return jnp.clip(correlation(u, v, w=w, centered=False), 0.0, 2.0)
 
 
-@implements(scipy.spatial.distance.euclidean)
 def euclidean(u: jax.Array, v: jax.Array, w: typing.Optional[jax.Array] = None) -> jax.Array:
   """Computes the Euclidean distance between two 1-D arrays."""
   return minkowski(u, v, p=2, w=w)
 
 
-@implements(scipy.spatial.distance.hamming)
 def hamming(u: jax.Array, v: jax.Array, w: typing.Optional[jax.Array] = None) -> jax.Array:
   """Compute the Hamming distance between two 1-D arrays."""
   u_ne_v = u != v
   if w is not None:
-    u_ne_v = u_ne_v.astype(w)
+    u_ne_v = u_ne_v.astype(w.dtype)
   return jnp.average(u_ne_v, weights=w)
 
 
-@implements(scipy.spatial.distance.jaccard)
 def jaccard(u, v, w=None):
   """Compute the Jaccard-Needham dissimilarity between two boolean 1-D arrays."""
   nonzero = jnp.bitwise_or(u != 0, v != 0)
@@ -115,7 +102,6 @@ def jaccard(u, v, w=None):
   return jnp.where(b != 0, a / b, 0)
 
 
-@implements(scipy.spatial.distance.minkowski)
 @functools.partial(jax.jit, static_argnames=['p'])
 def minkowski(u: jax.Array, v: jax.Array, p: int = 2, w: typing.Optional[jax.Array] = None) -> jax.Array:
   """Compute the Minkowski distance between two 1-D arrays."""
@@ -126,7 +112,7 @@ def minkowski(u: jax.Array, v: jax.Array, p: int = 2, w: typing.Optional[jax.Arr
     elif p == 2:
       root_w = jnp.sqrt(w)
     elif p == jnp.inf:
-      root_w = (w != 0).astype(w)
+      root_w = (w != 0).astype(w.dtype)
     else:
       root_w = jnp.power(w, 1/p)
     u_v = root_w * u_v
@@ -134,7 +120,6 @@ def minkowski(u: jax.Array, v: jax.Array, p: int = 2, w: typing.Optional[jax.Arr
   return dist
 
 
-@implements(scipy.spatial.distance.russellrao)
 def russellrao(u: jax.Array, v: jax.Array, w: typing.Optional[jax.Array] = None) -> jax.Array:
   """Compute the Russell-Rao dissimilarity between two boolean 1-D arrays."""
   if u.dtype == v.dtype == bool and w is None:
@@ -149,7 +134,6 @@ def russellrao(u: jax.Array, v: jax.Array, w: typing.Optional[jax.Array] = None)
   return (n - ntt) / n
 
 
-@implements(scipy.spatial.distance.sqeuclidean)
 def sqeuclidean(u: jax.Array, v: jax.Array, w: typing.Optional[jax.Array] = None) -> jax.Array:
   """Compute the squared Euclidean distance between two 1-D arrays."""
   u_v = u - v

--- a/src/jax_scipy_spatial/distance.py
+++ b/src/jax_scipy_spatial/distance.py
@@ -90,18 +90,6 @@ def hamming(u: jax.Array, v: jax.Array, w: typing.Optional[jax.Array] = None) ->
   return jnp.average(u_ne_v, weights=w)
 
 
-def jaccard(u, v, w=None):
-  """Compute the Jaccard-Needham dissimilarity between two boolean 1-D arrays."""
-  nonzero = jnp.bitwise_or(u != 0, v != 0)
-  unequal_nonzero = jnp.bitwise_and((u != v), nonzero)
-  if w is not None:
-    nonzero = jnp.where(nonzero, w, 0.)
-    unequal_nonzero = jnp.where(unequal_nonzero, w, 0.)
-  a = jnp.sum(unequal_nonzero)
-  b = jnp.sum(nonzero)
-  return jnp.where(b != 0, a / b, 0)
-
-
 @functools.partial(jax.jit, static_argnames=['p'])
 def minkowski(u: jax.Array, v: jax.Array, p: int = 2, w: typing.Optional[jax.Array] = None) -> jax.Array:
   """Compute the Minkowski distance between two 1-D arrays."""
@@ -118,20 +106,6 @@ def minkowski(u: jax.Array, v: jax.Array, p: int = 2, w: typing.Optional[jax.Arr
     u_v = root_w * u_v
   dist = jnp.linalg.norm(u_v, ord=p)
   return dist
-
-
-def russellrao(u: jax.Array, v: jax.Array, w: typing.Optional[jax.Array] = None) -> jax.Array:
-  """Compute the Russell-Rao dissimilarity between two boolean 1-D arrays."""
-  if u.dtype == v.dtype == bool and w is None:
-    ntt = jnp.sum(u & v)
-    n = u.size
-  elif w is None:
-    ntt = jnp.sum(u * v)
-    n = u.size
-  else:
-    ntt = jnp.sum(u * v * w)
-    n = jnp.sum(w)
-  return (n - ntt) / n
 
 
 def sqeuclidean(u: jax.Array, v: jax.Array, w: typing.Optional[jax.Array] = None) -> jax.Array:

--- a/src/jax_scipy_spatial/distance.py
+++ b/src/jax_scipy_spatial/distance.py
@@ -15,8 +15,6 @@
 import functools
 import typing
 
-import scipy.spatial.distance
-
 import jax
 import jax.numpy as jnp
 

--- a/src/jax_scipy_spatial/transform.py
+++ b/src/jax_scipy_spatial/transform.py
@@ -176,7 +176,8 @@ class Rotation:
 
   def mean(self, weights: typing.Optional[jax.Array] = None):
     """Get the mean of the rotations."""
-    weights = jnp.where(weights is None, jnp.ones(self._quat.shape[0], dtype=self._quat.dtype), jnp.asarray(weights, dtype=self._quat.dtype))
+    if weights is None:
+      weights = jnp.ones(self._quat.shape[0], dtype=self._quat.dtype)
     if weights.ndim != 1:
       raise ValueError(f"Expected `weights` to be 1 dimensional, got shape {weights.shape}.")
     if weights.shape[0] != len(self):

--- a/src/jax_scipy_spatial/transform.py
+++ b/src/jax_scipy_spatial/transform.py
@@ -21,13 +21,8 @@ import scipy.spatial.transform
 
 import jax
 import jax.numpy as jnp
-try:
-  from jax._src.numpy.util import implements
-except ImportError:
-  from jax._src.numpy.util import _wraps as implements  # for jax < 0.4.25
 
 
-@implements(scipy.spatial.transform.Rotation)
 class Rotation:
   """Rotation in 3 dimensions."""
 
@@ -217,7 +212,6 @@ jax.tree_util.register_pytree_node(
 )
 
 
-@implements(scipy.spatial.transform.Slerp)
 class Slerp:
   """Spherical Linear Interpolation of Rotations."""
 

--- a/src/jax_scipy_spatial/transform.py
+++ b/src/jax_scipy_spatial/transform.py
@@ -17,8 +17,6 @@ import functools
 import re
 import typing
 
-import scipy.spatial.transform
-
 import jax
 import jax.numpy as jnp
 
@@ -52,12 +50,6 @@ class Rotation:
       return cls.from_matrix(matrix), rssd, sensitivity
     else:
       return cls.from_matrix(matrix), rssd
-
-  @classmethod
-  def create_group(cls, group: str, axis: str = 'Z', dtype=float):
-    """Create a 3D rotation group."""
-    quat = scipy.spatial.transform.Rotation.create_group(group, axis).as_quat()
-    return cls.from_quat(jnp.array(quat, dtype=dtype))
 
   @classmethod
   def concatenate(cls, rotations: typing.Sequence):

--- a/src/jax_scipy_spatial/transform.py
+++ b/src/jax_scipy_spatial/transform.py
@@ -77,7 +77,10 @@ class Rotation:
     if any(seq[i] == seq[i+1] for i in range(num_axes - 1)):
       raise ValueError(f"Expected consecutive axes to be different, got {seq}")
     axes = jnp.array([_elementary_basis_index(x) for x in seq.lower()])
-    quat = _elementary_quat_compose(angles.reshape(-1, axes.size), axes, intrinsic, degrees)
+    angles = jnp.atleast_2d(angles)
+    if angles.shape[1] != num_axes:
+      raise ValueError(f"Expected last dimension of `angles` to match number of sequence axes specified, got {angles.shape[1]}.")
+    quat = _elementary_quat_compose(angles, axes, intrinsic, degrees)
     return cls(quat)
 
   @classmethod

--- a/tests/scipy_spatial_distance_test.py
+++ b/tests/scipy_spatial_distance_test.py
@@ -65,8 +65,6 @@ class LaxBackedScipySpatialDistanceTests(jtu.JaxTestCase):
       'cosine',
       'euclidean',
       'hamming',
-      'jaccard',
-      'russellrao',
       'sqeuclidean',
     ],
     dtype=float_dtypes,

--- a/tests/scipy_spatial_transform_test.py
+++ b/tests/scipy_spatial_transform_test.py
@@ -295,9 +295,8 @@ class LaxBackedScipySpatialTransformTests(jtu.JaxTestCase):
     args_maker = lambda: (rng(shape, dtype), jnp.abs(rng(shape[0], dtype)) if rng_weights else None)
     jnp_fn = lambda q, w: jsp_Rotation.from_quat(q).mean(w).as_quat()
     np_fn = lambda q, w: osp_Rotation.from_quat(q).mean(w).as_quat().astype(dtype)  # HACK
-    tol = 5e-3 if jtu.device_under_test() == 'tpu' else 1e-4
-    self._CheckQuaternionAgainstNumpy(np_fn, jnp_fn, args_maker, tol=tol)
-    self._CompileAndCheck(jnp_fn, args_maker, tol=tol)
+    self._CheckQuaternionAgainstNumpy(np_fn, jnp_fn, args_maker, tol=1e-4)
+    self._CompileAndCheck(jnp_fn, args_maker, tol=1e-4)
 
   @jtu.sample_product(
     dtype=float_dtypes,

--- a/tests/scipy_spatial_transform_test.py
+++ b/tests/scipy_spatial_transform_test.py
@@ -209,7 +209,7 @@ class LaxBackedScipySpatialTransformTests(jtu.JaxTestCase):
   def testRotationFromSingleEuler(self, size, dtype, seq, degrees):
     assert len(seq) == 1
     rng = jtu.rand_default(self.rng())
-    shape = (size,)
+    shape = (size, 1)
     args_maker = lambda: (rng(shape, dtype),)
     jnp_fn = lambda a: jsp_Rotation.from_euler(seq, a, degrees).as_quat()
     np_fn = lambda a: osp_Rotation.from_euler(seq, a, degrees).as_quat().astype(dtype)  # HACK

--- a/tests/scipy_spatial_transform_test.py
+++ b/tests/scipy_spatial_transform_test.py
@@ -222,7 +222,7 @@ class LaxBackedScipySpatialTransformTests(jtu.JaxTestCase):
   )
   def testRotationFromMatrix(self, shape, dtype):
     rng = jtu.rand_default(self.rng())
-    args_maker = lambda: (rng(shape, dtype),)
+    args_maker = lambda: (onp.linalg.qr(rng(shape, dtype))[0],)
     jnp_fn = lambda m: jsp_Rotation.from_matrix(m).as_quat()
     np_fn = lambda m: osp_Rotation.from_matrix(m).as_quat().astype(dtype)  # HACK
     self._CheckQuaternionAgainstNumpy(np_fn, jnp_fn, args_maker, tol=1e-4)

--- a/tests/scipy_spatial_transform_test.py
+++ b/tests/scipy_spatial_transform_test.py
@@ -73,29 +73,6 @@ class LaxBackedScipySpatialTransformTests(jtu.JaxTestCase):
 
   @jtu.sample_product(
     dtype=float_dtypes,
-    group=['I', 'O', 'T'],
-  )
-  def testRotationCreateGroup(self, group, dtype):
-    args_maker = lambda: (None,)
-    jnp_fn = lambda x: jsp_Rotation.create_group(group, dtype=dtype).as_quat()
-    np_fn = lambda x: osp_Rotation.create_group(group).as_quat()
-    self._CheckQuaternionAgainstNumpy(np_fn, jnp_fn, args_maker, tol=1e-4)
-    self._CompileAndCheck(jnp_fn, args_maker, tol=1e-4)
-
-  @jtu.sample_product(
-    dtype=float_dtypes,
-    group=['C1', 'D1', 'C2', 'D2', 'C3', 'D3'],
-    axis=['Z', 'Y', 'X'],
-  )
-  def testRotationCreateGroupWithAxis(self, group, axis, dtype):
-    args_maker = lambda: (None,)
-    jnp_fn = lambda x: jsp_Rotation.create_group(group, axis, dtype).as_quat()
-    np_fn = lambda x: osp_Rotation.create_group(group, axis).as_quat()
-    self._CheckQuaternionAgainstNumpy(np_fn, jnp_fn, args_maker, tol=1e-4)
-    self._CompileAndCheck(jnp_fn, args_maker, tol=1e-4)
-
-  @jtu.sample_product(
-    dtype=float_dtypes,
     shape=[(4,), (num_samples, 4)],
     seq=['xyz', 'zyx', 'XYZ', 'ZYX'],
     degrees=[True, False],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38, py312
+envlist = py312
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py312
+envlist = py312,py313,py314
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py312,py313,py314
+envlist = py312,py314
 
 [testenv]
 deps =


### PR DESCRIPTION
Gets the latest version of JAX working. Removes scipy dependency.

Removed the following functions:
- `transform.Rotation.create_group` (scipy dependency)
- `distance.jaccard` (boolean distance)
- `distance.russellrao` (boolean distance)